### PR TITLE
fix compile warnings for --warnings-as-errors

### DIFF
--- a/lib/buffers/buf_proc/buffer_reducer.ex
+++ b/lib/buffers/buf_proc/buffer_reducer.ex
@@ -9,11 +9,6 @@ defmodule Quillex.Buffer.Process.Reducer do
   # ===========================================================================
 
   @doc """
-  Push current state onto undo stack before making a change.
-  Call this BEFORE modifying data/cursor/selection, not after.
-  Clears the redo stack (new changes invalidate redo history).
-  """
-  @doc """
   Process undo action - restore previous state from undo stack.
   """
   def process(%BufState{} = buf, :undo), do: History.undo(buf)

--- a/lib/gui/scenes/root/qlx_root_scene.ex
+++ b/lib/gui/scenes/root/qlx_root_scene.ex
@@ -489,13 +489,6 @@ defmodule QuillEx.RootScene do
       new_state =
         Enum.reduce(actions, old_state, fn action, acc_state ->
           RootScene.Reducer.process(acc_state, action)
-          |> case do
-            :ignore ->
-              acc_state
-
-            new_acc_state ->
-              new_acc_state
-          end
         end)
 
       # Reuse existing graph to preserve component PIDs and avoid race conditions
@@ -515,12 +508,6 @@ defmodule QuillEx.RootScene do
     dispatch_toggle(toggle)
     {:noreply, scene}
   end
-
-  defp dispatch_toggle(:toggle_line_numbers),
-    do: Quillex.RadixCache.ViewStore.toggle_line_numbers()
-
-  defp dispatch_toggle(:toggle_word_wrap), do: Quillex.RadixCache.ViewStore.toggle_word_wrap()
-  defp dispatch_toggle(:toggle_file_nav), do: Quillex.RadixCache.ViewStore.toggle_file_nav()
 
   # Buffer-list actions are store dispatches: BufferManager owns that state,
   # and the scene re-renders when the :radix_buffers snapshot arrives.
@@ -733,6 +720,12 @@ defmodule QuillEx.RootScene do
     {:noreply, scene}
   end
 
+  defp dispatch_toggle(:toggle_line_numbers),
+    do: Quillex.RadixCache.ViewStore.toggle_line_numbers()
+
+  defp dispatch_toggle(:toggle_word_wrap), do: Quillex.RadixCache.ViewStore.toggle_word_wrap()
+  defp dispatch_toggle(:toggle_file_nav), do: Quillex.RadixCache.ViewStore.toggle_file_nav()
+
   # Buffer-list store snapshots (:radix_buffers) — the single path by which
   # the open-buffers list, active buffer, and dirty flags reach the scene.
   def handle_info(
@@ -768,6 +761,27 @@ defmodule QuillEx.RootScene do
   # catch-all on {{Scenic.PubSub, _}, _} would swallow :data updates.
   def handle_info({{Scenic.PubSub, :registered}, _}, scene), do: {:noreply, scene}
   def handle_info({{Scenic.PubSub, :unregistered}, _}, scene), do: {:noreply, scene}
+
+  def handle_info({:quit_requested, dirty_buffers}, scene) do
+    names = Enum.map_join(dirty_buffers, "\n", &"• #{&1.name || "untitled"}")
+    state = %{scene.assigns.state | show_unsaved_prompt: true, quit_dirty_buffers: dirty_buffers}
+
+    graph =
+      ScenicWidgets.ConfirmDialog.add_to_graph(
+        scene.assigns.graph,
+        %{
+          frame: state.frame,
+          title: "Unsaved Changes",
+          message: "The following buffers have unsaved changes:\n\n#{names}",
+          buttons: [{:discard, "Quit Without Saving"}, {:cancel, "Cancel"}]
+        },
+        id: :quit_prompt
+      )
+
+    new_scene = scene |> assign(state: state) |> assign(graph: graph) |> push_graph(graph)
+    Scenic.Scene.put_child(new_scene, :buffer_pane, :blur)
+    {:noreply, new_scene}
+  end
 
   # The single render path for store snapshots: diff-render against the
   # previous state, preserving component PIDs where the Renderizer allows.
@@ -1745,27 +1759,6 @@ defmodule QuillEx.RootScene do
     Scenic.Scene.put_child(new_scene, :buffer_pane, :focus)
 
     new_scene
-  end
-
-  def handle_info({:quit_requested, dirty_buffers}, scene) do
-    names = Enum.map_join(dirty_buffers, "\n", &"• #{&1.name || "untitled"}")
-    state = %{scene.assigns.state | show_unsaved_prompt: true, quit_dirty_buffers: dirty_buffers}
-
-    graph =
-      ScenicWidgets.ConfirmDialog.add_to_graph(
-        scene.assigns.graph,
-        %{
-          frame: state.frame,
-          title: "Unsaved Changes",
-          message: "The following buffers have unsaved changes:\n\n#{names}",
-          buttons: [{:discard, "Quit Without Saving"}, {:cancel, "Cancel"}]
-        },
-        id: :quit_prompt
-      )
-
-    new_scene = scene |> assign(state: state) |> assign(graph: graph) |> push_graph(graph)
-    Scenic.Scene.put_child(new_scene, :buffer_pane, :blur)
-    {:noreply, new_scene}
   end
 
   defp hide_quit_prompt(scene) do

--- a/lib/gui/scenes/root/qlx_root_scene_renderizer.ex
+++ b/lib/gui/scenes/root/qlx_root_scene_renderizer.ex
@@ -584,13 +584,6 @@ defmodule QuillEx.RootScene.Renderizer do
     # publishes a different document (same for buffer-process restarts: the
     # pane dispatch target is the PaneStore, never a raw buffer pid).
 
-    # Editor settings are applied IN PLACE (see apply_buffer_pane_settings/3):
-    # recreating the pane opens a window where the old TextField has died and
-    # the new one has not yet requested input, and anything typed or clicked
-    # in that window is lost. Settings alone therefore no longer force a
-    # rebuild.
-    settings_changed = false
-
     # Recreate if search bar, replace mode, or file nav visibility changed (affects buffer frame size)
     layout_changed =
       old_state.show_search_bar != new_state.show_search_bar or
@@ -606,7 +599,7 @@ defmodule QuillEx.RootScene.Renderizer do
     # resize" bug from the 2026-07-31 QA notes.
     frame_changed = old_state.frame != new_state.frame
 
-    settings_changed or layout_changed or status_bar_changed or frame_changed
+    layout_changed or status_bar_changed or frame_changed
   end
 
   # Helper to create the buffer_pane TextField

--- a/lib/test_helpers/semantic_helpers.ex
+++ b/lib/test_helpers/semantic_helpers.ex
@@ -291,10 +291,6 @@ defmodule Quillex.TestHelpers.SemanticHelpers do
   end
   
   @doc """
-  Get the current cursor position from the buffer's semantic data.
-  Returns {line, column} or nil if not found.
-  """
-  @doc """
   The buffer pane's actual frame `%{x:, y:, width:, height:}` in window
   coords, from the TextField's semantic metadata. Spex must derive
   window-size-dependent click coordinates (scrollbars, right-edge UI) from

--- a/mix.exs
+++ b/mix.exs
@@ -11,10 +11,13 @@ defmodule QuillEx.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:boundary] ++ Mix.compilers() ++ spex_compilers(),
       spex: [pattern: "test/spex/**/*_spex.exs", boundary: Quillex.Spex],
-      preferred_cli_env: [spex: :test, run_spex: :test],
       releases: releases(),
       deps: deps()
     ]
+  end
+
+  def cli do
+    [preferred_envs: [spex: :test, run_spex: :test]]
   end
 
   # `mix release` bundles the app, its deps and the ERTS into


### PR DESCRIPTION
Migrate preferred_cli_env to def cli (Elixir 1.19 deprecation), remove orphaned @doc attrs, dead settings_changed binding, and unreachable :ignore branch, and group handle_cast/handle_info clauses that were split by private helpers.

Ran on Elixir 1.19. All of it seems pretty mechanical